### PR TITLE
Fixed ship interface controller being world coord aligned, also Zero Core repo fix.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -192,10 +192,6 @@ repositories {
         name = "Valkyrien Skies Internal"
         url = 'https://maven.valkyrienskies.org'
     }
-    maven {
-       name "zerocore"//MF IS DEAD
-        url "https://maven.zerono.it/"
-    }
 
 
 }
@@ -208,8 +204,7 @@ dependencies {
 
 
     //ZEROCORE
-    compileOnly group: "it.zerono.mods.zerocore", name: "ZeroCore2", version: "1.20.1-2.1.47"
-    implementation 'it.zerono.mods.zerocore:ZeroCore2:1.20.1-2.1.47'
+    implementation fg.deobf("curse.maven:zerocore-247921:7344725")
 
     implementation         ("org.valkyrienskies.core:api:${vs_core_version}")
     implementation         ("org.valkyrienskies.core:impl:${vs_core_version}")

--- a/src/main/kotlin/net/illuc/kontraption/blockEntities/TileEntityShipControlInterface.kt
+++ b/src/main/kotlin/net/illuc/kontraption/blockEntities/TileEntityShipControlInterface.kt
@@ -39,7 +39,7 @@ import net.minecraftforge.common.MinecraftForge
 import net.minecraftforge.common.capabilities.Capability
 import net.minecraftforge.common.util.LazyOptional
 import net.minecraftforge.fml.ModList
-import net.minecraftforge.network.NetworkHooks
+import net.minecraftforge.network.NetworkHooks     
 import org.joml.Quaterniond
 import org.joml.Vector3d
 import org.joml.Vector3dc
@@ -142,8 +142,20 @@ class TileEntityShipControlInterface(
                         seatedControllingPlayer!!.upImpulse.coerceIn(-1.0, 1.0),
                         seatedControllingPlayer!!.leftImpulse.coerceIn(-1.0, 1.0),
                     )
-                // I had a stroke reading this line. also frick lint
-                velTarget.set(f, u, l)
+                // Transform input based on block facing direction and ship rotation
+                val facing = this.direction
+                val forwardDir = facing.opposite.normal.toJOMLD()
+                val leftDir = facing.counterClockWise.normal.toJOMLD()
+
+                // Calculate ship velocity target
+                val shipLocalX = forwardDir.x() * f + leftDir.x() * l
+                val shipLocalZ = forwardDir.z() * f + leftDir.z() * l
+                val shipLocalVelocity = Vector3d(shipLocalX, u, shipLocalZ)
+
+                // Transform from local to world coordinates using the ship rotation
+                val shipTransform = ship.transform
+                val worldVelocity = shipTransform.shipToWorld.transformDirection(shipLocalVelocity, Vector3d())
+                velTarget.set(worldVelocity)
                 if (seatedControllingPlayer!!.openConfig) {
                     val player = entity.controllingPassenger as ServerPlayer
                     val configBlocks = getConfigBlocks()


### PR DESCRIPTION
If not already refactoring Ship Interface controller, then this is a small but impactful fix that makes the controls based on the block's facing direction. Also optional Zero Core repo replacement.