### PR TITLE
Fix multiple issues

### DIFF
--- a/src/main/java/net/illuc/kontraption/util/KontraptionVSUtils.java
+++ b/src/main/java/net/illuc/kontraption/util/KontraptionVSUtils.java
@@ -6,6 +6,7 @@ import net.minecraft.server.level.ServerLevel;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.phys.BlockHitResult;
 import org.joml.Vector3d;
+import org.joml.Vector3ic;
 import org.valkyrienskies.core.api.ships.ServerShip;
 import org.valkyrienskies.core.api.world.ServerShipWorld;
 import org.valkyrienskies.core.internal.ShipTeleportData;
@@ -49,7 +50,19 @@ public class KontraptionVSUtils {
 
 
     public static void createNewShipWithBlocks(BlockPos pos, DenseBlockPosSet set, ServerLevel level){
-        ShipAssemblyKt.createNewShipWithBlocks(pos, set, level);//TODO: Its structure now, get corners n shit
+
+        // use assembleToShip() method replace the outdated one to be compatible with VK 2.4.10
+        java.util.List<net.minecraft.core.BlockPos> blockList = new java.util.ArrayList<>();
+        for (org.joml.Vector3ic vec : set) {
+            blockList.add(new net.minecraft.core.BlockPos(vec.x(), vec.y(), vec.z()));
+        }
+        org.valkyrienskies.mod.common.assembly.ShipAssembler.INSTANCE.assembleToShip(
+                level,
+                blockList,
+                true,
+                1.0,
+                false
+        );
     }
     public static String dimensionID(ServerLevel level){
         return  VSGameUtilsKt.getDimensionId(level);

--- a/src/main/kotlin/net/illuc/kontraption/ThrusterInterface.kt
+++ b/src/main/kotlin/net/illuc/kontraption/ThrusterInterface.kt
@@ -25,6 +25,8 @@ interface ThrusterInterface {
         if (level !is ServerLevel) return // INITAL FUCKIN SETUP
         // println("ENABLED")
         if (worldPosition != null) {
+            // maybe forget to switch "enabled" true, that cause all thrusters became unavailable
+            enabled = true
             val ship =
                 KontraptionVSUtils.getShipObjectManagingPos(level, bpos)
                     ?: KontraptionVSUtils.getShipManagingPos(level, bpos)

--- a/src/main/kotlin/net/illuc/kontraption/multiblocks/largeHydrogenThruster/LiquidFuelThrusterMultiblockData.kt
+++ b/src/main/kotlin/net/illuc/kontraption/multiblocks/largeHydrogenThruster/LiquidFuelThrusterMultiblockData.kt
@@ -1,6 +1,7 @@
 package net.illuc.kontraption.multiblocks.largeHydrogenThruster
 
 import mekanism.api.Action
+import mekanism.api.AutomationType
 import mekanism.api.chemical.attribute.ChemicalAttributeValidator
 import mekanism.api.chemical.gas.Gas
 import mekanism.api.chemical.gas.IGasTank
@@ -119,7 +120,7 @@ class LiquidFuelThrusterMultiblockData(
         }
 
         if (powered and enabled) {
-            if (Dist.DEDICATED_SERVER.isDedicatedServer and (thrusterLevel != null)) {
+            if (thrusterLevel is ServerLevel) {
                 particleDir =
                     if (ship == null) {
                         exhaustDirection.normal.multiply(innerVolume).toJOMLD()
@@ -139,8 +140,9 @@ class LiquidFuelThrusterMultiblockData(
         var storedFuel: Double = gasTank!!.stored + burnRemaining
         val powerPerc = currentThrust / thrusterPower
         val toBurn = thrusterPower * KontraptionConfigs.kontraption.liquidFuelConsumption.get() * powerPerc // Math.min(Math.min(1.0, storedFuel), fuelAssemblies * MekanismGeneratorsConfig.generators.burnPerAssembly.get())
-        storedFuel -= toBurn
-        if (storedFuel <= 0.0) {
+        // fix the default config problem with dirty way
+        val totalToBurn = ((toBurn + burnRemaining)/10000.0).coerceAtMost(gasTank!!.capacity.toDouble()-1)
+        if (storedFuel < totalToBurn) {
             if (enabled) {
                 disable()
             }
@@ -149,8 +151,13 @@ class LiquidFuelThrusterMultiblockData(
                 enable()
             }
         }
-        gasTank!!.setStackSize(storedFuel.toLong(), Action.EXECUTE)
-        burnRemaining = storedFuel % 1
+        //gasTank!!.setStackSize(storedFuel.toLong().coerceAtLeast(0), Action.EXECUTE)
+        // use extract method instead directly modify tankSize to avoid setting tankSize too small to restart the thruster
+        val extractAmount = totalToBurn.toLong()
+        if (extractAmount > 0L) {
+            gasTank!!.extract(extractAmount, Action.EXECUTE, AutomationType.INTERNAL)
+        }
+        burnRemaining = (totalToBurn - extractAmount).coerceAtLeast(0.0)
         // heatCapacitor.handleHeat(toBurn * MekanismGeneratorsConfig.generators.energyPerFissionFuel.get().doubleValue())
         // update previous burn
         lastBurnRate = toBurn

--- a/src/main/kotlin/net/illuc/kontraption/ship/KontraptionThrusterControl.kt
+++ b/src/main/kotlin/net/illuc/kontraption/ship/KontraptionThrusterControl.kt
@@ -76,9 +76,12 @@ class KontraptionThrusterControl : ShipPhysicsListener {
 
             if (alignment > 0.0) {
                 val maxForce = thr.thruster.thrusterPower * KontraptionConfigs.kontraption.ionThrust.get()
+                // what is this meaning? xThrust power in config * ionThrust power? Is ion engine power as a power unit?
                 val applied = min(alignment, maxForce)
 
                 thr.thruster.powered = true
+                thr.thruster.currentThrust = applied
+                // update the currentThrust to which thrust actually applied (or the thruster will never consume any fuel)
 
                 physShip.applyWorldForce(
                     worldDir.mul(applied, Vector3d())


### PR DESCRIPTION
1. Fix crashing while using toolgun assemble ship on VK 2.4.10
2. All types of thrusters unavailable due to a "enable" deadlock
3. Thrusters unable to consume fuel due to a var update problem
4. Liquid thrusters now can normally consume H2 instead of changing the tank size(it can cause a logic deadlock and prevent the thruster restart when the tank size too small !!)